### PR TITLE
Add colon to the co-author string so co-authors can be read by GitHub

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -123,7 +123,7 @@ class CoAuthoring {
 
   public getPairingString () {
     return [ ...this.pairingSet.values() ]
-      .map(buddy => `Co-authored-by ${buddy}`)
+      .map(buddy => `Co-authored-by: ${buddy}`)
       .join('\n');
   }
 


### PR DESCRIPTION
GitHub requires this [specific format](https://help.github.com/articles/creating-a-commit-with-multiple-authors/) to show co-authors as additional authors in its UI.